### PR TITLE
Feature/vi text objects

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -261,7 +261,12 @@ impl Buffer {
 
     /// Insert contents of register to the right or to the left of start in the current buffer
     /// and return length of text inserted.
-    pub fn insert_register_around_cursor(&mut self, mut start: usize, right: bool) -> usize {
+    pub fn insert_register_around_cursor(
+        &mut self,
+        mut start: usize,
+        count: usize,
+        right: bool,
+    ) -> usize {
         let mut inserted = 0;
         if let Some(text) = self.register.as_ref() {
             inserted = text.len();
@@ -271,11 +276,19 @@ impl Buffer {
                     start += 1;
                 }
 
-                let act = Action::Insert {
-                    start,
-                    text: text.clone(),
+                let text = if count > 1 {
+                    let mut full_text = Vec::with_capacity(text.len() * count);
+                    for _i in 0..count {
+                        for c in text.iter() {
+                            full_text.push(*c);
+                        }
+                    }
+                    inserted = full_text.len();
+                    full_text
+                } else {
+                    text.to_vec()
                 };
-                self.insert_action(act);
+                self.insert_action(Action::Insert { start, text });
             }
         }
         inserted

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -244,6 +244,11 @@ impl Buffer {
 
     /// Returns the number of characters removed.
     pub fn remove(&mut self, start: usize, end: usize) -> usize {
+        let end = if end >= self.data.len() {
+            self.data.len()
+        } else {
+            end
+        };
         let s = self.remove_raw(start, end);
         let num_removed = s.len();
         self.push_action(Action::Remove {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -894,6 +894,19 @@ impl<'a> Editor<'a> {
         self.display()
     }
 
+    pub fn cursor_is_at_beginning_of_word(&self) -> bool {
+        let buf = cur_buf!(self);
+        let num_chars = buf.num_chars();
+        let cursor_pos = self.cursor;
+        if num_chars > 0 && cursor_pos != 0 {
+            let c = buf.char_before(cursor_pos);
+            if let Some(c) = c {
+                return c.is_whitespace();
+            }
+        }
+        true
+    }
+
     pub fn cursor_is_at_end_of_line(&self) -> bool {
         let num_chars = cur_buf!(self).num_chars();
         if self.no_eol {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -434,9 +434,9 @@ impl<'a> Editor<'a> {
 
     /// Inserts characters to the right or the left of the cursor, moving the cursor to the last
     /// character inserted.
-    pub fn paste(&mut self, right: bool) -> usize {
+    pub fn paste(&mut self, right: bool, count: usize) -> usize {
         let buf = cur_buf_mut!(self);
-        buf.insert_register_around_cursor(self.cursor, right)
+        buf.insert_register_around_cursor(self.cursor, count, right)
     }
 
     pub fn revert(&mut self) -> io::Result<bool> {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -894,7 +894,7 @@ impl<'a> Editor<'a> {
         self.display()
     }
 
-    pub fn cursor_is_at_beginning_of_word(&self) -> bool {
+    pub fn cursor_at_beginning_of_word_or_line(&self) -> bool {
         let buf = cur_buf!(self);
         let num_chars = buf.num_chars();
         let cursor_pos = self.cursor;


### PR DESCRIPTION
add support for text objects 'aw' and 'iw' with number support and commands [d | c | y] to support key combos like '4ciw' and '2yaw'

also add number support for 'p' and 'P' so key combos like '3p' and '2P' function properly.